### PR TITLE
Issue #50: Allow to launch ScenicView from within a path containing spaces

### DIFF
--- a/src/main/java/org/fxconnector/remote/RemoteConnectorImpl.java
+++ b/src/main/java/org/fxconnector/remote/RemoteConnectorImpl.java
@@ -429,7 +429,7 @@ class RemoteConnectorImpl extends UnicastRemoteObject implements RemoteConnector
                 /**
                  * Find jar distributed in custom image
                  */
-                tempf = new File(new URL("file:///" + System.getProperty("java.home") + "/lib/scenicview.jar").toURI());
+                tempf = new File(System.getProperty("java.home") + "/lib/scenicview.jar");
             }
         } catch (MalformedURLException | URISyntaxException e) {
             ExceptionLogger.submitException(e, "Attempting to get agent jar.");


### PR DESCRIPTION
Fix for #50 : Allow spaces in installation path.
Test case:
clone repository int a path containing spaces, then
```
> gradlew jlink
> cd build\scenicview\bin
> .\scenicView
Platform running
Launching ScenicView v11.0.2
Startup done
Creating server
Server done
Number of running Java applications found: 4
Obtaining properties for Java application with PID:800
Obtaining properties for Java application with PID:17492
Obtaining properties for Java application with PID:15308
0 JavaFX applications found
java.net.URISyntaxException: Illegal character in path at index 15: file:/D:/Scenic View/build/scenicview/lib/scenicview.jar
        at java.base/java.net.URI$Parser.fail(Unknown Source)
        at java.base/java.net.URI$Parser.checkChars(Unknown Source)
        at java.base/java.net.URI$Parser.parseHierarchical(Unknown Source)
        at java.base/java.net.URI$Parser.parse(Unknown Source)
        at java.base/java.net.URI.<init>(Unknown Source)
        at java.base/java.net.URL.toURI(Unknown Source)
        at org.scenicview.scenicview/org.fxconnector.remote.RemoteConnectorImpl.findAgent(Unknown Source)
        at org.scenicview.scenicview/org.fxconnector.remote.RemoteConnectorImpl.connect(Unknown Source)
        at org.scenicview.scenicview/org.scenicview.model.update.RemoteVMsUpdateStrategy.getActiveApps(Unknown Source)
        at org.scenicview.scenicview/org.scenicview.model.update.RemoteVMsUpdateStrategy.work(Unknown Source)
        at org.scenicview.scenicview/org.fxconnector.helper.WorkerThread.run(Unknown Source)
Error: Unable to find agent jar file. Exiting Scenic View.
```
After bugfix:
```
> .\scenicView
Platform running
Launching ScenicView v11.0.2
Startup done
Creating server
Server done
Number of running Java applications found: 4
Obtaining properties for Java application with PID:800
Obtaining properties for Java application with PID:17492
Obtaining properties for Java application with PID:15308
0 JavaFX applications found
Loading agent from: D:\Scenic View\build\scenicview\lib\scenicview.jar
```