### PR TITLE
Issue #52: Expose the result of Node.toString() in the details pane.

### DIFF
--- a/src/main/java/org/fxconnector/details/NodeDetailPaneInfo.java
+++ b/src/main/java/org/fxconnector/details/NodeDetailPaneInfo.java
@@ -44,6 +44,7 @@ import org.fxconnector.event.FXConnectorEventDispatcher;
 class NodeDetailPaneInfo extends DetailPaneInfo {
 
     Detail nodeClassName;
+    Detail nodeToString;
     Detail pseudoClassStateDetail;
     Detail styleClassDetail;
     Detail managedDetail;
@@ -88,6 +89,7 @@ class NodeDetailPaneInfo extends DetailPaneInfo {
 
     @Override protected void createDetails() {
         nodeClassName = addDetail("className", "className:");
+        nodeToString = addDetail("toString", "toString:");
         styleClassDetail = addDetail("styleClass", "styleClass:");
         pseudoClassStateDetail = addDetail(null, "pseudoClassState:");
         visibleDetail = addDetail("visible", "visible:");
@@ -249,8 +251,10 @@ class NodeDetailPaneInfo extends DetailPaneInfo {
         final boolean all = propertyName.equals("*") ? true : false;
 
         final Node node = (Node) getTarget();
+
         if (all && node != null) {
             nodeClassName.setValue(node.getClass().getName());
+            nodeToString.setValue(node.toString());
         }
 
         if (node != null) {

--- a/src/main/java/org/scenicview/view/tabs/DetailsTab.java
+++ b/src/main/java/org/scenicview/view/tabs/DetailsTab.java
@@ -70,7 +70,7 @@ public class DetailsTab extends Tab implements ContextMenuContainer {
         this.loader = loader;
 
         ScrollPane scrollPane = new ScrollPane();
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
         scrollPane.setFitToWidth(true);
         vbox = new VBox();
         vbox.setFillWidth(true);


### PR DESCRIPTION
Also made the details pane horizontally scrollable to see all text displayed for the various properties (this is useful for the new toString() row, but also was an issue with existing rows where the output could not be completely read if it was rather long, without resizing the application window and/or moving the splitter).