### PR TITLE
Error: Unable to find agent jar file. Exiting Scenic View.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ jar {
     archiveName = 'scenicview.jar'
 }
 
+run {
+	dependsOn jar
+}
+
 artifacts {
     archives(jar)
 }


### PR DESCRIPTION
Closes #60 https://github.com/JonathanGiles/scenic-view/issues/60#issue-618534727

When scenic-view is started with `gradlew run`, the application won't start, instead an error message occurs. Running `gradlew jar run` instead works fine. Hence, modifying the `run` task to execute `jar` upfront solves the problem for `gradlew run`.