### PR TITLE
Fix exceptions while highlighting nodes

### DIFF
--- a/src/main/java/org/fxconnector/SCUtils.java
+++ b/src/main/java/org/fxconnector/SCUtils.java
@@ -131,7 +131,7 @@ class SCUtils {
                 return hovered;
         }
         final Point2D localPoint = target.sceneToLocal(x, y);
-        if (target.contains(localPoint) && ((!configuration.isIgnoreMouseTransparent() || !ConnectorUtils.isMouseTransparent(target)) && ConnectorUtils.isNodeVisible(target))) {
+        if (localPoint != null && target.contains(localPoint) && ((!configuration.isIgnoreMouseTransparent() || !ConnectorUtils.isMouseTransparent(target)) && ConnectorUtils.isNodeVisible(target))) {
             return target;
         }
 


### PR DESCRIPTION
Under certain circumstances the `Node#sceneToLocal` method returns null - when highlighting components using the menu `"Scenegraph/ Component highlight/ select on click"` this exception can be observed in some applications while moving the mouse over it - also it starts to hang and the highlighting doesn't work properly anymore:

```
java.lang.NullPointerException: Cannot invoke "javafx.geometry.Point2D.getX()" because "<parameter1>" is null
	at javafx.graphics@21.0.6-internal/javafx.scene.Node.contains(Node.java:4143)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:134)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.SCUtils.getHoveredNode(SCUtils.java:129)
	at org.fxconnector.StageControllerImpl.getHoveredNode(StageControllerImpl.java:537)
	at org.fxconnector.StageControllerImpl.highlightHovered(StageControllerImpl.java:521)
	at org.fxconnector.StageControllerImpl.lambda$new$0(StageControllerImpl.java:127)
```

A check that `localPoint `is not null fixes the issue - it will still highlight the node below the one that cannot be transformed which is fine.