### PR TITLE
Don't force the modena stylesheet on the application that embeds ScenicView

### DIFF
--- a/src/main/java/org/scenicview/ScenicView.java
+++ b/src/main/java/org/scenicview/ScenicView.java
@@ -169,8 +169,6 @@ public class ScenicView extends Application {
 //        System.setProperty(FXConnector.SCENIC_VIEW_VM, "true");
         startup();
 
-        setUserAgentStylesheet(STYLESHEET_MODENA);
-
         final RemoteVMsUpdateStrategy strategy = new RemoteVMsUpdateStrategy();
 
         // workaround for RT-10714

--- a/src/main/java/org/scenicview/utils/SceneCreator.java
+++ b/src/main/java/org/scenicview/utils/SceneCreator.java
@@ -1,0 +1,34 @@
+/*
+ * Scenic View, 
+ * Copyright (C) 2025 Jonathan Giles, Ander Ruiz, Amy Fowler 
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.scenicview.utils;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+
+public final class SceneCreator {
+  public static Scene newScene(Parent root) {
+    return newScene(root, -1, -1);
+  }
+  public static Scene newScene(Parent root, double width, double height) {
+    Scene scene = new Scene(root, width, height);
+    scene.setUserAgentStylesheet("com/sun/javafx/scene/control/skin/modena/modena.css"); 
+    return scene;
+  }
+}
+

--- a/src/main/java/org/scenicview/view/ScenicViewGui.java
+++ b/src/main/java/org/scenicview/view/ScenicViewGui.java
@@ -81,6 +81,7 @@ import org.scenicview.model.update.AppsRepository;
 import org.scenicview.model.update.UpdateStrategy;
 import org.scenicview.utils.ExceptionLogger;
 import org.scenicview.utils.Logger;
+import static org.scenicview.utils.SceneCreator.newScene;
 import org.scenicview.view.control.FilterTextField;
 import org.scenicview.view.dialog.AboutBox;
 import org.scenicview.view.dialog.HelpBox;
@@ -973,8 +974,9 @@ public class ScenicViewGui {
 //    }
 
     public static void show(final ScenicViewGui scenicview, final Stage stage) {
-        final Scene scene = new Scene(scenicview.rootBorderPane);
+        final Scene scene = newScene(scenicview.rootBorderPane);
         scene.getStylesheets().addAll(STYLESHEETS);
+        scene.setUserAgentStylesheet("com/sun/javafx/scene/control/skin/modena/modena.css");
         stage.setScene(scene);
         stage.getIcons().add(APP_ICON);
         if (scenicview.activeStage != null && scenicview.activeStage instanceof StageControllerImpl)

--- a/src/main/java/org/scenicview/view/dialog/AboutBox.java
+++ b/src/main/java/org/scenicview/view/dialog/AboutBox.java
@@ -18,6 +18,7 @@
 package org.scenicview.view.dialog;
 
 import org.scenicview.utils.PropertiesUtils;
+import static org.scenicview.utils.SceneCreator.newScene;
 import org.scenicview.view.DisplayUtils;
 import org.scenicview.view.ScenicViewGui;
 import org.scenicview.ScenicView;
@@ -77,7 +78,7 @@ public class AboutBox {
         this.panel.setAlignment(Pos.TOP_CENTER);
         this.panel.getChildren().addAll(this.header, this.textArea, this.footer);
 
-        this.scene = new Scene(panel, SCENE_WIDTH, SCENE_HEIGHT);
+        this.scene = newScene(panel, SCENE_WIDTH, SCENE_HEIGHT);
 
         this.stage = new Stage(StageStyle.UTILITY);
         this.stage.setTitle(title);

--- a/src/main/java/org/scenicview/view/dialog/HelpBox.java
+++ b/src/main/java/org/scenicview/view/dialog/HelpBox.java
@@ -27,6 +27,7 @@ import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
 import org.fxconnector.StageController;
+import static org.scenicview.utils.SceneCreator.newScene;
 import org.scenicview.view.control.ProgressWebView;
 import org.scenicview.view.DisplayUtils;
 
@@ -49,7 +50,7 @@ public class HelpBox {
         wview.setPrefWidth(SCENE_WIDTH);
         wview.doLoad(url);
         pane.setCenter(wview);
-        final Scene scene = new Scene(pane, SCENE_WIDTH, SCENE_HEIGHT); 
+        final Scene scene = newScene(pane, SCENE_WIDTH, SCENE_HEIGHT); 
         stage = new Stage();
         stage.setTitle(title);
         stage.setScene(scene);

--- a/src/main/java/org/scenicview/view/dialog/InfoBox.java
+++ b/src/main/java/org/scenicview/view/dialog/InfoBox.java
@@ -33,6 +33,7 @@ import javafx.stage.StageStyle;
 import javafx.stage.Window;
 
 import org.fxconnector.StageController;
+import static org.scenicview.utils.SceneCreator.newScene;
 import org.scenicview.view.ScenicViewGui;
 
 public class InfoBox {
@@ -57,7 +58,7 @@ public class InfoBox {
             final String textAreaText, final boolean editable, final int width, final int height) {
         final VBox pane = new VBox(20);
         pane.setId(StageController.FX_CONNECTOR_BASE_ID + "InfoBox");
-        final Scene scene = new Scene(pane, width, height); 
+        final Scene scene = newScene(pane, width, height); 
 
         final Stage stage = new Stage(StageStyle.UTILITY);
         stage.setTitle(title);

--- a/src/main/java/org/scenicview/view/dialog/SubmitExceptionDialog.java
+++ b/src/main/java/org/scenicview/view/dialog/SubmitExceptionDialog.java
@@ -34,6 +34,7 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
+import static org.scenicview.utils.SceneCreator.newScene;
 import org.scenicview.view.ScenicViewGui;
 
 public class SubmitExceptionDialog {
@@ -110,7 +111,7 @@ public class SubmitExceptionDialog {
 
         Platform.runLater(new Runnable() {
             @Override public void run() {
-                scene = new Scene(panel, SCENE_WIDTH, SCENE_HEIGHT);
+                scene = newScene(panel, SCENE_WIDTH, SCENE_HEIGHT);
 
                 stage = new Stage(StageStyle.UTILITY);
                 stage.setTitle("Exception");


### PR DESCRIPTION
By calling `Application#setUserStylesheet` in  https://github.com/JonathanGiles/scenic-view/blob/master/src/main/java/org/scenicview/ScenicView.java#L172 the user stylesheet of the embedding application will be changed too and vice versa, compare demo that breaks ScenicView's look & feel:
```java
import javafx.application.Application;
import javafx.stage.Stage;
import javafx.scene.Scene;
import javafx.scene.layout.BorderPane;
import javafx.scene.chart.LineChart;
import javafx.scene.chart.NumberAxis;
import javafx.scene.control.ToggleButton;
import javafx.scene.image.ImageView;
import org.scenicview.ScenicView;

public class JFXDemo extends Application {
  public void start(Stage stage) {
    ToggleButton button = new ToggleButton("Hello");
    BorderPane root = new BorderPane(button);
    Scene scene = new Scene(root);
    stage.setScene(scene);
    setUserAgentStylesheet(getClass().getResource("demo.css").toString());
    ScenicView.show(scene);
    stage.show();

  }
  public static void main(String[] args) {
    Application.launch(JFXDemo.class, args);
  }
}
```
where demo.css looks like this:
```css
.toggle-button {
  -fx-background-color: "red";
}
```
compile and run with OpenJDK 21 & OpenJFX 21 (tested on Windows):
```cmd
javac -cp "%SCENICVIEW_HOME%/scenicview.jar" --module-path %JAVAFX_SDK%/lib --add-modules javafx.graphics,javafx.controls JFXDemo.java
java -cp .;"%SCENICVIEW_HOME%/scenicview.jar" --module-path %JAVAFX_SDK%/lib --add-modules javafx.graphics,javafx.controls,javafx.web,javafx.fxml JFXDemo
```

ScenicView will look like this:

![BrokenScenicView](https://github.com/user-attachments/assets/fa23c0f8-2008-4c75-9a1e-5b756d072f3b)

A way to solve this is proposed by this pull request to set the modena.css Stylesheet directly on the ScenicView's scenes.